### PR TITLE
feat: add Unified Accounts chain extension contract

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -116,11 +116,16 @@ impl BuildConfig {
             )
             .unwrap();
 
-            // copy metadata
+            // copy metadata & .contract file
             if let Some(res) = build.metadata_result {
                 fs::copy(
                     res.dest_metadata,
                     self.fixtures_dir.join(format!("{contract}.json")),
+                )
+                .unwrap();
+                fs::copy(
+                    res.dest_bundle,
+                    self.fixtures_dir.join(format!("{contract}.contract")),
                 )
                 .unwrap();
             }

--- a/contracts/au-ce-getters/.gitignore
+++ b/contracts/au-ce-getters/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/contracts/au-ce-getters/Cargo.toml
+++ b/contracts/au-ce-getters/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "au-ce-getters"
+version = "0.1.0"
+authors = ["Stake Technologies <devops@stake.co.jp>"]
+edition = "2021"
+homepage = "https://astar.network"
+repository = "https://github.com/AstarNetwork/ink-test-contracts"
+
+[dependencies]
+ink = { version = "4.2.0", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2.6", default-features = false, features = [
+    "derive",
+], optional = true }
+unified-accounts-chain-extension-types = { git = "https://github.com/AstarNetwork/Astar", branch = "feat/au-storage-fee-and-ce", version = "0.1.0", default-features = false }
+
+# substrate
+sp-core = { version = "24.0.0", default-features = false }
+
+[dev-dependencies]
+ink_e2e = "4.2.0"
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "sp-core/std",
+    "unified-accounts-chain-extension-types/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/contracts/au-ce-getters/helper.rs
+++ b/contracts/au-ce-getters/helper.rs
@@ -1,0 +1,75 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use core::marker::PhantomData;
+use ink::env::{DefaultEnvironment, Environment};
+use sp_core::H160;
+pub use unified_accounts_chain_extension_types::Command;
+
+/// UA Extension Interface
+pub struct UAExtension<E = DefaultEnvironment, const ID: u16 = 03>(PhantomData<E>);
+
+impl<E: Environment, const ID: u16> UAExtension<E, ID> {
+    const fn get_func_id(idx: u16) -> u32 {
+        ((ID as u32) << 16) + (idx as u32)
+    }
+
+    pub fn to_h160(account_id: E::AccountId) -> Option<H160> {
+        let func_id: u32 = Self::get_func_id(Command::GetEvmAddress.into());
+
+        // fn(AccountId) -> Option<H160>
+        ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
+            .input::<E::AccountId>()
+            .output::<Option<H160>, false>()
+            .ignore_error_code()
+            .call(&(account_id))
+    }
+
+    pub fn to_h160_or_default(account_id: E::AccountId) -> H160 {
+        let func_id: u32 = Self::get_func_id(Command::GetEvmAddressOrDefault.into());
+
+        // fn(AccountId) -> H160
+        ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
+            .input::<E::AccountId>()
+            .output::<H160, false>()
+            .ignore_error_code()
+            .call(&(account_id))
+    }
+
+    pub fn to_account_id(evm_address: H160) -> Option<E::AccountId> {
+        let func_id: u32 = Self::get_func_id(Command::GetNativeAddress.into());
+
+        // fn(H160) -> Option<AccountId>
+        ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
+            .input::<H160>()
+            .output::<Option<E::AccountId>, false>()
+            .ignore_error_code()
+            .call(&(evm_address))
+    }
+
+    pub fn to_account_id_or_default(evm_address: H160) -> E::AccountId {
+        let func_id: u32 = Self::get_func_id(Command::GetNativeAddressOrDefault.into());
+
+        // fn(H160) -> AccountId
+        ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
+            .input::<H160>()
+            .output::<E::AccountId, false>()
+            .ignore_error_code()
+            .call(&(evm_address))
+    }
+}

--- a/contracts/au-ce-getters/helper.rs
+++ b/contracts/au-ce-getters/helper.rs
@@ -40,13 +40,13 @@ impl<E: Environment, const ID: u16> UAExtension<E, ID> {
             .call(&(account_id))
     }
 
-    pub fn to_h160_or_default(account_id: E::AccountId) -> H160 {
+    pub fn to_h160_or_default(account_id: E::AccountId) -> (H160, bool) {
         let func_id: u32 = Self::get_func_id(Command::GetEvmAddressOrDefault.into());
 
         // fn(AccountId) -> H160
         ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
             .input::<E::AccountId>()
-            .output::<H160, false>()
+            .output::<(H160, bool), false>()
             .ignore_error_code()
             .call(&(account_id))
     }
@@ -62,13 +62,13 @@ impl<E: Environment, const ID: u16> UAExtension<E, ID> {
             .call(&(evm_address))
     }
 
-    pub fn to_account_id_or_default(evm_address: H160) -> E::AccountId {
+    pub fn to_account_id_or_default(evm_address: H160) -> (E::AccountId, bool) {
         let func_id: u32 = Self::get_func_id(Command::GetNativeAddressOrDefault.into());
 
         // fn(H160) -> AccountId
         ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
             .input::<H160>()
-            .output::<E::AccountId, false>()
+            .output::<(E::AccountId, bool), false>()
             .ignore_error_code()
             .call(&(evm_address))
     }

--- a/contracts/au-ce-getters/helper.rs
+++ b/contracts/au-ce-getters/helper.rs
@@ -19,7 +19,7 @@
 use core::marker::PhantomData;
 use ink::env::{DefaultEnvironment, Environment};
 use sp_core::H160;
-pub use unified_accounts_chain_extension_types::Command;
+pub use unified_accounts_chain_extension_types::{Command, UnifiedAddress};
 
 /// UA Extension Interface
 pub struct UAExtension<E = DefaultEnvironment, const ID: u16 = 03>(PhantomData<E>);
@@ -40,13 +40,13 @@ impl<E: Environment, const ID: u16> UAExtension<E, ID> {
             .call(&(account_id))
     }
 
-    pub fn to_h160_or_default(account_id: E::AccountId) -> (H160, bool) {
+    pub fn to_h160_or_default(account_id: E::AccountId) -> UnifiedAddress<H160> {
         let func_id: u32 = Self::get_func_id(Command::GetEvmAddressOrDefault.into());
 
         // fn(AccountId) -> H160
         ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
             .input::<E::AccountId>()
-            .output::<(H160, bool), false>()
+            .output::<UnifiedAddress<H160>, false>()
             .ignore_error_code()
             .call(&(account_id))
     }
@@ -62,13 +62,13 @@ impl<E: Environment, const ID: u16> UAExtension<E, ID> {
             .call(&(evm_address))
     }
 
-    pub fn to_account_id_or_default(evm_address: H160) -> (E::AccountId, bool) {
+    pub fn to_account_id_or_default(evm_address: H160) -> UnifiedAddress<E::AccountId> {
         let func_id: u32 = Self::get_func_id(Command::GetNativeAddressOrDefault.into());
 
         // fn(H160) -> AccountId
         ::ink::env::chain_extension::ChainExtensionMethod::build(func_id)
             .input::<H160>()
-            .output::<(E::AccountId, bool), false>()
+            .output::<UnifiedAddress<E::AccountId>, false>()
             .ignore_error_code()
             .call(&(evm_address))
     }

--- a/contracts/au-ce-getters/lib.rs
+++ b/contracts/au-ce-getters/lib.rs
@@ -49,7 +49,7 @@ mod call_xvm_payable {
         }
 
         #[ink(message, selector = 43)]
-        pub fn to_h160_or_default(&self, account_id: AccountId) -> H160 {
+        pub fn to_h160_or_default(&self, account_id: AccountId) -> (H160, bool) {
             UAExtension::to_h160_or_default(account_id)
         }
 
@@ -59,7 +59,7 @@ mod call_xvm_payable {
         }
 
         #[ink(message, selector = 45)]
-        pub fn to_account_id_or_default(&self, evm_address: H160) -> AccountId {
+        pub fn to_account_id_or_default(&self, evm_address: H160) -> (AccountId, bool) {
             UAExtension::to_account_id_or_default(evm_address)
         }
     }

--- a/contracts/au-ce-getters/lib.rs
+++ b/contracts/au-ce-getters/lib.rs
@@ -1,0 +1,66 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+//! Contract for cross-VM payable calls test.
+//!
+//! This contract can call an EVM contract via `pallet-xvm` via Chain Extension.
+
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+mod helper;
+
+use helper::UAExtension as _UAExtension;
+use ink::env::DefaultEnvironment;
+use sp_core::H160;
+
+type UAExtension = _UAExtension<DefaultEnvironment>;
+
+#[ink::contract]
+mod call_xvm_payable {
+    use super::*;
+
+    #[ink(storage)]
+    pub struct UAMappingGetter;
+
+    impl UAMappingGetter {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        #[ink(message, payable, selector = 42)]
+        pub fn to_h160(&self, account_id: AccountId) -> Option<H160> {
+            UAExtension::to_h160(account_id)
+        }
+
+        #[ink(message, payable, selector = 43)]
+        pub fn to_h160_or_default(&self, account_id: AccountId) -> H160 {
+            UAExtension::to_h160_or_default(account_id)
+        }
+
+        #[ink(message, payable, selector = 44)]
+        pub fn to_account_id(&self, evm_address: H160) -> Option<AccountId> {
+            UAExtension::to_account_id(evm_address)
+        }
+
+        #[ink(message, payable, selector = 45)]
+        pub fn to_account_id_or_default(&self, evm_address: H160) -> AccountId {
+            UAExtension::to_account_id_or_default(evm_address)
+        }
+    }
+}

--- a/contracts/au-ce-getters/lib.rs
+++ b/contracts/au-ce-getters/lib.rs
@@ -24,7 +24,7 @@
 
 mod helper;
 
-use helper::UAExtension as _UAExtension;
+use helper::{UAExtension as _UAExtension, UnifiedAddress};
 use ink::env::DefaultEnvironment;
 use sp_core::H160;
 
@@ -49,7 +49,7 @@ mod call_xvm_payable {
         }
 
         #[ink(message, selector = 43)]
-        pub fn to_h160_or_default(&self, account_id: AccountId) -> (H160, bool) {
+        pub fn to_h160_or_default(&self, account_id: AccountId) -> UnifiedAddress<H160> {
             UAExtension::to_h160_or_default(account_id)
         }
 
@@ -59,7 +59,7 @@ mod call_xvm_payable {
         }
 
         #[ink(message, selector = 45)]
-        pub fn to_account_id_or_default(&self, evm_address: H160) -> (AccountId, bool) {
+        pub fn to_account_id_or_default(&self, evm_address: H160) -> UnifiedAddress<AccountId> {
             UAExtension::to_account_id_or_default(evm_address)
         }
     }

--- a/contracts/au-ce-getters/lib.rs
+++ b/contracts/au-ce-getters/lib.rs
@@ -43,22 +43,22 @@ mod call_xvm_payable {
             Self {}
         }
 
-        #[ink(message, payable, selector = 42)]
+        #[ink(message, selector = 42)]
         pub fn to_h160(&self, account_id: AccountId) -> Option<H160> {
             UAExtension::to_h160(account_id)
         }
 
-        #[ink(message, payable, selector = 43)]
+        #[ink(message, selector = 43)]
         pub fn to_h160_or_default(&self, account_id: AccountId) -> H160 {
             UAExtension::to_h160_or_default(account_id)
         }
 
-        #[ink(message, payable, selector = 44)]
+        #[ink(message, selector = 44)]
         pub fn to_account_id(&self, evm_address: H160) -> Option<AccountId> {
             UAExtension::to_account_id(evm_address)
         }
 
-        #[ink(message, payable, selector = 45)]
+        #[ink(message, selector = 45)]
         pub fn to_account_id_or_default(&self, evm_address: H160) -> AccountId {
             UAExtension::to_account_id_or_default(evm_address)
         }


### PR DESCRIPTION
The contract `UAMappingGetter` exports all the methods from unified accounts chain extension.
The `helper.rs` file provides interface over CE